### PR TITLE
Corrected online compiler url

### DIFF
--- a/docs/installing-vyper.rst
+++ b/docs/installing-vyper.rst
@@ -11,7 +11,7 @@ any errors.
 
 .. note::
    The easiest way to try out the language, experiment with examples, and compile code to ``bytecode``
-   or ``LLL`` is to use the online compiler at https://vyper.tools.
+   or ``LLL`` is to use the online compiler at https://vyper.online.
 
 *************
 Prerequisites


### PR DESCRIPTION
### - What I did
Document contained a link to an unregistered domain ( https://vyper.tools ).
Replaced with link to https://vyper.online/

### - How I did it

### - How to verify it

### - Description for the changelog
Replaced https://vyper.tools with link to https://vyper.online/

### - Cute Animal Picture

> put a cute animal picture here.
![1513600947081](https://user-images.githubusercontent.com/999307/36899699-a3ebcf8a-1e63-11e8-814a-38327d36e957.jpg)
